### PR TITLE
update patent_search_assistant_reasoning_engine.ipynb

### DIFF
--- a/patent_search_assistant_reasoning_engine.ipynb
+++ b/patent_search_assistant_reasoning_engine.ipynb
@@ -380,7 +380,7 @@
     {
       "cell_type": "code",
       "source": [
-        "vector_store.similarity_search(\"patent related to natural language processing\")"
+        "similarity_search(\"patent related to natural language processing\")"
       ],
       "metadata": {
         "colab": {


### PR DESCRIPTION
Fixes a typo which causes scripts to fail.